### PR TITLE
correcting uuid check to the nwnx plugin for peekUUID.

### DIFF
--- a/src/main/NWN/API/Object/NwObject.cs
+++ b/src/main/NWN/API/Object/NwObject.cs
@@ -47,6 +47,14 @@ namespace NWN.API
     }
 
     /// <summary>
+    /// Gets if this object has an assigned UUID.
+    /// </summary>
+    public bool HasUUID
+    {
+      get => string.IsNullOrEmpty(ObjectPlugin.PeekUUID(this));
+    }
+
+    /// <summary>
     /// Returns the resource reference used to create this object.
     /// </summary>
     public string ResRef => NWScript.GetResRef(this);
@@ -172,9 +180,19 @@ namespace NWN.API
       return new LocalUUID(this, name);
     }
 
-    public bool HasUUID()
+    /// <summary>
+    /// Attempts to get the UUID of this object, if assigned.
+    /// </summary>
+    /// <returns>The UUID if assigned, otherwise no value.</returns>
+    public Guid? PeekUUID()
     {
-      return string.IsNullOrEmpty(NWNX.API.Object.PeekUUID(this));
+      string guidString = ObjectPlugin.PeekUUID(this);
+      if (!string.IsNullOrWhiteSpace(guidString))
+      {
+        return Guid.Parse(guidString);
+      }
+
+      return null;
     }
 
     public void ForceRefreshUUID()

--- a/src/main/NWN/API/Object/NwObject.cs
+++ b/src/main/NWN/API/Object/NwObject.cs
@@ -172,9 +172,9 @@ namespace NWN.API
       return new LocalUUID(this, name);
     }
 
-    public bool HasClashingUUID()
+    public bool HasUUID()
     {
-      return string.IsNullOrEmpty(NWScript.GetObjectUUID(this));
+      return string.IsNullOrEmpty(NWNX.API.Object.PeekUUID(this));
     }
 
     public void ForceRefreshUUID()

--- a/src/main/NWNX/API/Object.cs
+++ b/src/main/NWNX/API/Object.cs
@@ -56,5 +56,10 @@ namespace NWNX.API
     {
       ObjectPlugin.SetPlaceableIsStatic(placeable, value.ToInt());
     }
+
+    public static string PeekUUID(this NwObject obj)
+    {
+      return ObjectPlugin.PeekUUID(obj);
+    }
   }
 }


### PR DESCRIPTION
Should achieve the desired result of checking if a uuid has been set for an object.