### PR TITLE
Faction API

### DIFF
--- a/src/main/NWN/API/Extensions/StandardFactionExtensions.cs
+++ b/src/main/NWN/API/Extensions/StandardFactionExtensions.cs
@@ -1,0 +1,35 @@
+using NWN.API.Constants;
+using NWN.Core;
+
+namespace NWN.API
+{
+  /// <summary>
+  /// Extension methods for getting and setting options of standard factions.
+  /// </summary>
+  public static class StandardFactionExtensions
+  {
+    /// <summary>
+    /// Gets an integer between 0 and 100 (inclusive) that represents how this faction feels about the specified target.<br/>
+    ///  -> 0-10 means this faction is hostile to the target<br/>
+    ///  -> 11-89 means this faction is neutral to the target<br/>
+    ///  -> 90-100 means this faction is friendly to the target.
+    /// </summary>
+    /// <param name="faction">The source faction.</param>
+    /// <param name="target">The target object.</param>
+    /// <returns>0-100 (inclusive) based on the standing of the target within this standard faction.</returns>
+    public static int GetReputation(this StandardFaction faction, NwGameObject target)
+      => NWScript.GetStandardFactionReputation((int) faction, target);
+
+    /// <summary>
+    /// Sets how this standard faction feels about the specified creature.<br/>
+    ///  -> 0-10 means this faction is hostile to the target.<br/>
+    ///  -> 11-89 means this faction is neutral to the target.<br/>
+    ///  -> 90-100 means this faction is friendly to the target.
+    /// </summary>
+    /// <param name="faction">The source faction.</param>
+    /// <param name="target">The target object.</param>
+    /// <param name="newReputation">A value between 0-100 (inclusive).</param>
+    public static void SetReputation(this StandardFaction faction, NwGameObject target, int newReputation)
+      => NWScript.SetStandardFactionReputation((int) faction, newReputation, target);
+  }
+}

--- a/src/main/NWN/API/Object/NwCreature.cs
+++ b/src/main/NWN/API/Object/NwCreature.cs
@@ -368,6 +368,13 @@ namespace NWN.API
     }
 
     /// <summary>
+    /// Forces this creature to join the specified standard faction. This will NOT work on players.
+    /// </summary>
+    /// <param name="newFaction">The NPCs new faction.</param>
+    public void ChangeToStandardFaction(StandardFaction newFaction)
+      => NWScript.ChangeToStandardFaction(this, (int) newFaction);
+
+    /// <summary>
     /// Gets whether this creature has a specific immunity.
     /// </summary>
     /// <param name="immunityType">The immunity type to check.</param>

--- a/src/main/NWN/API/Object/NwFaction.cs
+++ b/src/main/NWN/API/Object/NwFaction.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Collections.Generic;
+using NWN.API.Constants;
+using NWN.Core;
+
+namespace NWN.API
+{
+  public sealed class NwFaction : IEquatable<NwFaction>
+  {
+    internal readonly NwGameObject GameObject;
+
+    public NwFaction(NwGameObject gameObject)
+    {
+      this.GameObject = gameObject;
+    }
+
+    /// <summary>
+    /// Gets the most common type of class among the members of this faction/party.
+    /// </summary>
+    public ClassType MostFrequentClass
+    {
+      get => (ClassType) NWScript.GetFactionMostFrequentClass(GameObject);
+    }
+
+    public int AverageLevel
+    {
+      get => NWScript.GetFactionAverageLevel(GameObject);
+    }
+
+    public int AverageXP
+    {
+      get => NWScript.GetFactionAverageXP(GameObject);
+    }
+
+    /// <summary>
+    /// Get the total amount of gold held by all members of this party.
+    /// </summary>
+    public int Gold
+    {
+      get => NWScript.GetFactionGold(GameObject);
+    }
+
+    /// <summary>
+    /// Gets the members in this faction.
+    /// </summary>
+    /// <typeparam name="T">The types of members to get.</typeparam>
+    /// <returns></returns>
+    public IEnumerable<T> GetMembers<T>() where T : NwGameObject
+    {
+      int pcOnly = (typeof(T) == typeof(NwPlayer)).ToInt();
+
+      for (uint obj = NWScript.GetFirstFactionMember(GameObject, pcOnly);
+        obj != NWScript.OBJECT_INVALID;
+        obj = NWScript.GetNextFactionMember(GameObject, pcOnly))
+      {
+        T next = obj.ToNwObject<T>();
+        if (next != null)
+        {
+          yield return next;
+        }
+      }
+    }
+
+    public bool Equals(NwFaction other)
+    {
+      if (ReferenceEquals(null, other))
+      {
+        return false;
+      }
+
+      if (ReferenceEquals(this, other))
+      {
+        return true;
+      }
+
+      return NWScript.GetFactionEqual(GameObject, other.GameObject).ToBool();
+    }
+
+    public override bool Equals(object obj)
+    {
+      return ReferenceEquals(this, obj) || obj is NwFaction other && Equals(other);
+    }
+
+    public override int GetHashCode()
+    {
+      return (GameObject != null ? GameObject.GetHashCode() : 0);
+    }
+
+    public static bool operator ==(NwFaction left, NwFaction right)
+    {
+      return Equals(left, right);
+    }
+
+    public static bool operator !=(NwFaction left, NwFaction right)
+    {
+      return !Equals(left, right);
+    }
+  }
+}

--- a/src/main/NWN/API/Object/NwFaction.cs
+++ b/src/main/NWN/API/Object/NwFaction.cs
@@ -1,39 +1,53 @@
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using NWN.API.Constants;
 using NWN.Core;
 
 namespace NWN.API
 {
+  /// <summary>
+  /// The faction info of a Creature/Player/GameObject
+  /// </summary>
   public sealed class NwFaction : IEquatable<NwFaction>
   {
     internal readonly NwGameObject GameObject;
 
-    public NwFaction(NwGameObject gameObject)
+    internal NwFaction(NwGameObject gameObject)
     {
       this.GameObject = gameObject;
     }
 
     /// <summary>
-    /// Gets the most common type of class among the members of this faction/party.
+    /// Gets the most common type of class among the members of this faction/party.<br/>
+    /// @note This can be a costly operation when used on large NPC factions.
     /// </summary>
     public ClassType MostFrequentClass
     {
       get => (ClassType) NWScript.GetFactionMostFrequentClass(GameObject);
     }
 
+    /// <summary>
+    /// Gets the average level of members in this faction.<br/>
+    /// @note This can be a costly operation when used on large NPC factions.
+    /// </summary>
     public int AverageLevel
     {
       get => NWScript.GetFactionAverageLevel(GameObject);
     }
 
+    /// <summary>
+    /// Gets the average amount of XP of members in this faction.<br/>
+    /// @note This can be a costly operation when used on large NPC factions.
+    /// </summary>
     public int AverageXP
     {
       get => NWScript.GetFactionAverageXP(GameObject);
     }
 
     /// <summary>
-    /// Get the total amount of gold held by all members of this party.
+    /// Get the total amount of gold held by all members of this party.<br/>
+    /// @note This can be a costly operation when used on large NPC factions.
     /// </summary>
     public int Gold
     {
@@ -41,10 +55,91 @@ namespace NWN.API
     }
 
     /// <summary>
-    /// Gets the members in this faction.
+    /// Gets the average Good/Evil alignment value of members in this faction.<br/>
+    /// @note This can be a costly operation when used on large NPC factions.
     /// </summary>
-    /// <typeparam name="T">The types of members to get.</typeparam>
-    /// <returns></returns>
+    public int AverageGoodEvilAlignment
+    {
+      get => NWScript.GetFactionAverageGoodEvilAlignment(GameObject);
+    }
+
+    /// <summary>
+    /// Gets the average Law/Chaos alignment value of members in this faction.<br/>
+    /// @note This can be a costly operation when used on large NPC factions.
+    /// </summary>
+    public int AverageLawChaosAlignment
+    {
+      get => NWScript.GetFactionAverageLawChaosAlignment(GameObject);
+    }
+
+    /// <summary>
+    /// Gets the member with the highest AC in this faction.<br/>
+    /// @note This can be a costly operation when used on large NPC factions. Consider using <see cref="VisibleHighestACMember"/> instead.
+    /// </summary>
+    public NwGameObject HighestACMember
+    {
+      get => NWScript.GetFactionBestAC(GameObject, false.ToInt()).ToNwObject<NwGameObject>();
+    }
+
+    /// <summary>
+    /// Gets the member with the lowest AC in this faction.<br/>
+    /// @note This can be a costly operation when used on large NPC factions. Consider using <see cref="VisibleLowestACMember"/> instead.
+    /// </summary>
+    public NwGameObject LowestACMember
+    {
+      get => NWScript.GetFactionWorstAC(GameObject, false.ToInt()).ToNwObject<NwGameObject>();
+    }
+
+    /// <summary>
+    /// Gets the weakest member in this faction.<br/>
+    /// @note This can be a costly operation when used on large NPC factions. Consider using <see cref="VisibleWeakestMember"/> instead.
+    /// </summary>
+    public NwGameObject WeakestMember
+    {
+      get => NWScript.GetFactionWeakestMember(GameObject, false.ToInt()).ToNwObject<NwGameObject>();
+    }
+
+    /// <summary>
+    /// Gets the strongest member in this faction.<br/>
+    /// @note This can be a costly operation when used on large NPC factions. Consider using <see cref="VisibleStrongestMember"/> instead.
+    /// </summary>
+    public NwGameObject StrongestMember
+    {
+      get => NWScript.GetFactionStrongestMember(GameObject, false.ToInt()).ToNwObject<NwGameObject>();
+    }
+
+    /// <summary>
+    /// Gets the most damaged member in this faction.<br/>
+    /// @note This can be a costly operation when used on large NPC factions. Consider using <see cref="VisibleMostDamagedMember"/> instead.
+    /// </summary>
+    public NwGameObject MostDamagedMember
+    {
+      get => NWScript.GetFactionMostDamagedMember(GameObject, false.ToInt()).ToNwObject<NwGameObject>();
+    }
+
+    /// <summary>
+    /// Gets the least damaged member in this faction.<br/>
+    /// @note This can be a costly operation when used on large NPC factions. Consider using <see cref="VisibleLeastDamagedMember"/> instead.
+    /// </summary>
+    public NwGameObject LeastDamagedMember
+    {
+      get => NWScript.GetFactionLeastDamagedMember(GameObject, false.ToInt()).ToNwObject<NwGameObject>();
+    }
+
+    /// <summary>
+    /// Gets the leader of this player faction (party)<br/>
+    /// </summary>
+    public NwPlayer Leader
+    {
+      get => NWScript.GetFactionLeader(GameObject).ToNwObject<NwPlayer>();
+    }
+
+    /// <summary>
+    /// Gets the members in this faction.<br/>
+    /// @note This can be a very costly operation when used on large NPC factions.
+    /// </summary>
+    /// <typeparam name="T">The type of members to get.</typeparam>
+    /// <returns>All members in this faction of type T.</returns>
     public IEnumerable<T> GetMembers<T>() where T : NwGameObject
     {
       int pcOnly = (typeof(T) == typeof(NwPlayer)).ToInt();
@@ -59,6 +154,71 @@ namespace NWN.API
           yield return next;
         }
       }
+    }
+
+    /// <summary>
+    /// Gets an integer between 0 and 100 (inclusive) that represents how this faction feels about the specified target.<br/>
+    ///  -> 0-10 means this faction is hostile to the target<br/>
+    ///  -> 11-89 means this faction is neutral to the target<br/>
+    ///  -> 90-100 means this faction is friendly to the target<br/>
+    /// </summary>
+    /// <param name="target">The target object to check.</param>
+    /// <returns></returns>
+    public int GetAverageReputation(NwGameObject target)
+      => NWScript.GetFactionAverageReputation(GameObject, target);
+
+    /// <summary>
+    /// Gets the member with the highest AC in this faction that is visible from the specified object.
+    /// </summary>
+    public async Task<NwGameObject> VisibleHighestACMember(NwGameObject visibleFrom)
+    {
+      await visibleFrom.WaitForObjectContext();
+      return NWScript.GetFactionBestAC(GameObject, true.ToInt()).ToNwObject<NwGameObject>();
+    }
+
+    /// <summary>
+    /// Gets the member with the lowest AC in this faction that is visible from the specified object.
+    /// </summary>
+    public async Task<NwGameObject> VisibleLowestACMember(NwGameObject visibleFrom)
+    {
+      await visibleFrom.WaitForObjectContext();
+      return NWScript.GetFactionWorstAC(GameObject, true.ToInt()).ToNwObject<NwGameObject>();
+    }
+
+    /// <summary>
+    /// Gets the weakest member in this faction that is visible from the specified object.
+    /// </summary>
+    public async Task<NwGameObject> VisibleWeakestMember(NwGameObject visibleFrom)
+    {
+      await visibleFrom.WaitForObjectContext();
+      return NWScript.GetFactionWeakestMember(GameObject, true.ToInt()).ToNwObject<NwGameObject>();
+    }
+
+    /// <summary>
+    /// Gets the strongest member in this faction that is visible from the specified object.
+    /// </summary>
+    public async Task<NwGameObject> VisibleStrongestMember(NwGameObject visibleFrom)
+    {
+      await visibleFrom.WaitForObjectContext();
+      return NWScript.GetFactionStrongestMember(GameObject, true.ToInt()).ToNwObject<NwGameObject>();
+    }
+
+    /// <summary>
+    /// Gets the most damaged member in this faction that is visible from the specified object.
+    /// </summary>
+    public async Task<NwGameObject> VisibleMostDamagedMember(NwGameObject visibleFrom)
+    {
+      await visibleFrom.WaitForObjectContext();
+      return NWScript.GetFactionMostDamagedMember(GameObject, true.ToInt()).ToNwObject<NwGameObject>();
+    }
+
+    /// <summary>
+    /// Gets the least damaged member in this faction that is visible from the specified object.
+    /// </summary>
+    public async Task<NwGameObject> VisibleLeastDamagedMember(NwGameObject visibleFrom)
+    {
+      await visibleFrom.WaitForObjectContext();
+      return NWScript.GetFactionLeastDamagedMember(GameObject, true.ToInt()).ToNwObject<NwGameObject>();
     }
 
     public bool Equals(NwFaction other)

--- a/src/main/NWN/API/Object/NwGameObject.cs
+++ b/src/main/NWN/API/Object/NwGameObject.cs
@@ -10,7 +10,10 @@ namespace NWN.API
 {
   public abstract class NwGameObject : NwObject
   {
-    internal NwGameObject(uint objectId) : base(objectId) {}
+    internal NwGameObject(uint objectId) : base(objectId)
+    {
+      faction = new NwFaction(this);
+    }
 
     /// <summary>
     /// Gets or sets the location of this object.
@@ -31,6 +34,17 @@ namespace NWN.API
     public NwArea Area
     {
       get => NWScript.GetArea(this).ToNwObject<NwArea>();
+    }
+
+    private readonly NwFaction faction;
+
+    /// <summary>
+    /// Gets or sets the faction of this object.
+    /// </summary>
+    public NwFaction Faction
+    {
+      get => faction;
+      set => NWScript.ChangeFaction(this, value.GameObject);
     }
 
     /// <summary>
@@ -120,12 +134,26 @@ namespace NWN.API
     /// <summary>
     /// Gets the current HP for this object.
     /// </summary>
-    public int HP => NWScript.GetCurrentHitPoints(this);
+    public int HP
+    {
+      get => NWScript.GetCurrentHitPoints(this);
+    }
 
     /// <summary>
     /// Gets the maximum HP for this object. Returns 0 if this object has no defined HP.
     /// </summary>
-    public int MaxHP => NWScript.GetMaxHitPoints(this);
+    public int MaxHP
+    {
+      get => NWScript.GetMaxHitPoints(this);
+    }
+
+    /// <summary>
+    /// Gets the total amount of gold held by this object's faction.
+    /// </summary>
+    public int FactionGold
+    {
+      get => NWScript.GetFactionGold(this);
+    }
 
     /// <summary>
     /// Gets or sets this object's plot status.
@@ -337,6 +365,21 @@ namespace NWN.API
           throw new ArgumentOutOfRangeException(nameof(savingThrow), savingThrow, null);
       }
     }
+
+    /// <summary>
+    /// Changes this object's faction to that of another creature.
+    /// </summary>
+    /// <param name="newFactionMember">A creature whose faction will be joined.</param>
+    public void ChangeToFaction(NwCreature newFactionMember)
+      => NWScript.ChangeFaction(this, newFactionMember);
+
+    /// <summary>
+    /// Gets if this object and the specified object are in the same faction.
+    /// </summary>
+    /// <param name="other">The other object to compare against.</param>
+    /// <returns></returns>
+    public bool GetFactionEqual(NwGameObject other)
+      => NWScript.GetFactionEqual(this, other).ToBool();
 
     /// <summary>
     /// Casts a spell at an object.


### PR DESCRIPTION
Added a nested NwFaction type in NwGameObject that implements faction methods/properties, and a custom IEquatable interface.

For StandardFaction constants, these are implemented as extension methods on the enum.

Usage
**Check if players are in the same party**
```cs
      NwPlayer player1;
      NwPlayer player2;

      if (player1.Faction == player2.Faction)
      {
        // Player is in same party.
      }
```

**Move NPCs to a standard faction**
```cs
      NwCreature npc1;
      NwCreature npc2;

      // Change NPCs to a standard faction.
      npc1.ChangeToStandardFaction(StandardFaction.Hostile);
      npc2.ChangeToStandardFaction(StandardFaction.Commoner);
```

**Move a NPC to another NPC's faction**
```cs
      NwCreature npc1;
      NwCreature npc2;
      
      // Change NPC 2 to be the same faction as NPC 1
      npc2.Faction = npc1.Faction;
```

**Make a standard faction hate a player**
```cs
      NwPlayer player;
      StandardFaction.Merchant.SetReputation(player, 0);
```