### PR TITLE
fixed typo

### DIFF
--- a/src/main/NWNX/API/Events/ExamineEvents.cs
+++ b/src/main/NWNX/API/Events/ExamineEvents.cs
@@ -7,7 +7,7 @@ namespace NWNX.API.Events
   public class ExamineEvents
   {
     [NWNXEvent("NWNX_ON_EXAMINE_OBJECT_BEFORE")]
-    public class OnAddAssociateBefore : Event<OnAddAssociateBefore>
+    public class OnExamineObjectBefore : Event<OnExamineObjectBefore>
     {
       public NwPlayer Examiner { get; private set; }
 
@@ -24,7 +24,7 @@ namespace NWNX.API.Events
     }
 
     [NWNXEvent("NWNX_ON_EXAMINE_OBJECT_AFTER")]
-    public class OnAddAssociateAfter : Event<OnAddAssociateAfter>
+    public class OnExamineObjectAfter : Event<OnExamineObjectAfter>
     {
       public NwPlayer Examiner { get; private set; }
 


### PR DESCRIPTION
```
There is a typo in class name. Shouldn't it be OnExamineObjectBefore? https://github.com/nwn-dotnet/NWN.Managed/blob/97cf68e188b0e46a49252729351df5b7647d6bc6/src/main/NWNX/API/Events/ExamineEvents.cs#L10
```
[In regards to this comment in discord](https://discordapp.com/channels/714927668826472600/715651687150518273/773957941987377173)