### PR TITLE
Add "NWM_PREVENT_START_NO_PLUGIN" option.

### DIFF
--- a/src/main/NWN/EnvironmentConfig.cs
+++ b/src/main/NWN/EnvironmentConfig.cs
@@ -12,6 +12,7 @@ namespace NWN
     public static readonly string PluginsPath = Environment.GetEnvironmentVariable("NWM_PLUGIN_PATH") ?? Path.Combine(AssemblyConstants.AssemblyDir, "Plugins");
     public static readonly string NLogConfigPath = Environment.GetEnvironmentVariable("NWM_NLOG_CONFIG");
     public static readonly bool ReloadEnabled = string.Equals(Environment.GetEnvironmentVariable("NWM_RELOAD_ENABLED"), "true", StringComparison.InvariantCultureIgnoreCase);
+    public static readonly bool PreventStartNoPlugin = string.Equals(Environment.GetEnvironmentVariable("NWM_PREVENT_START_NO_PLUGIN"), "true", StringComparison.InvariantCultureIgnoreCase);
 
     // NWNX
     public static readonly string ModStartScript = Environment.GetEnvironmentVariable("NWNX_UTIL_PRE_MODULE_START_SCRIPT");

--- a/src/main/NWN/Plugins/PluginLoader.cs
+++ b/src/main/NWN/Plugins/PluginLoader.cs
@@ -38,6 +38,13 @@ namespace NWN.Plugins
     private void BootstrapPlugins()
     {
       string[] pluginPaths = Directory.GetDirectories(EnvironmentConfig.PluginsPath);
+
+      if (EnvironmentConfig.PreventStartNoPlugin && pluginPaths.Length == 0)
+      {
+        throw new Exception($"No plugins are available to load, and NWM_PREVENT_START_NO_PLUGIN is enabled.\n" +
+          $"Check your plugins are available at {EnvironmentConfig.PluginsPath}, or update NWM_PLUGIN_PATH to the correct location.");
+      }
+
       foreach (string pluginRoot in pluginPaths)
       {
         string pluginName = new DirectoryInfo(pluginRoot).Name;


### PR DESCRIPTION
Adds an option to prevent server startup if no plugins are available to load.

Enable by setting `NWM_PREVENT_START_NO_PLUGIN=true`