### PR TITLE
Delete directory only if exists

### DIFF
--- a/src/main/NWN/Services/ResourceManager/ResourceManager.cs
+++ b/src/main/NWN/Services/ResourceManager/ResourceManager.cs
@@ -113,7 +113,10 @@ namespace NWN.Services
 
     void IDisposable.Dispose()
     {
-      Directory.Delete(EnvironmentConfig.ResourcePath, true);
+      if (Directory.Exists(EnvironmentConfig.ResourcePath))
+      {
+        Directory.Delete(EnvironmentConfig.ResourcePath, true);
+      }
     }
   }
 }


### PR DESCRIPTION
Prevents crash on `AnvilCore.Reload()`