### PR TITLE
Convert damager to NwGameObject instead of NwCreature

### DIFF
--- a/NWN.Anvil/src/main/API/Events/Game/PlaceableEvents/PlaceableEvents.OnDamaged.cs
+++ b/NWN.Anvil/src/main/API/Events/Game/PlaceableEvents/PlaceableEvents.OnDamaged.cs
@@ -45,7 +45,7 @@ namespace Anvil.API.Events
         uint objSelf = NWScript.OBJECT_SELF;
         DamagedObject = objSelf.ToNwObject<NwPlaceable>()!;
         TotalDamageDealt = NWScript.GetTotalDamageDealt();
-        Damager = NWScript.GetLastDamager(objSelf).ToNwObject<NwCreature>()!;
+        Damager = NWScript.GetLastDamager(objSelf).ToNwObject<NwGameObject>();
       }
     }
   }


### PR DESCRIPTION
The damager was previously being cast to an NwCreature with null suppression, despite the API exposing it as a nullable `NwGameObject`.

I have first-hand experience with this throwing errors when non-creature damagers hurt placeables. (placeable origin traps, long story)
Apologies for the screenshot-of-text:

<img width="2809" height="393" alt="image" src="https://github.com/user-attachments/assets/01b54a54-32ac-4d80-b676-0152cbec477c" />
